### PR TITLE
Read more settings from config files

### DIFF
--- a/Code/assets/data/config/initial_game_data.json
+++ b/Code/assets/data/config/initial_game_data.json
@@ -1,5 +1,6 @@
 {
 	predatorSpeedIndex: 3
+	maxPredatorPowerUps: 1
 	levelsLocked: {
 		class: java.util.HashMap
 		1: false

--- a/Code/assets/data/config/physics_config.json
+++ b/Code/assets/data/config/physics_config.json
@@ -2,4 +2,5 @@
 	wallWidthRatio: 0.1
 	pillRadiusRatio: 0.2
 	powerUpRadiusRatio: 0.5
+	agentRadiusRatio: 0.95
 }

--- a/Code/assets/data/config/sandbox_config.json
+++ b/Code/assets/data/config/sandbox_config.json
@@ -4,4 +4,6 @@
 	mazeWidth: 6
 	mazeHeight: 10 
 	numPrey: 3
+	maxPredatorPowerUps: 5
+	powerUpStrengths: 1
 }

--- a/Code/data/PlayerProgress.java
+++ b/Code/data/PlayerProgress.java
@@ -8,14 +8,14 @@ import logic.powerup.PowerUpType;
 public class PlayerProgress {
 
 	private int predatorSpeedIndex;
+	private int maxPredatorPowerUps;
 	private Map<String, Boolean> levelsLocked;
 	private Map<String, Integer> levelScores;
 	private Map<String, Integer> powerUpDefinitions;
 	
-	// numPowerUps?
-	
 	public PlayerProgress() {
 		predatorSpeedIndex = 1;
+		maxPredatorPowerUps = 1;
 		levelsLocked = new HashMap<String, Boolean>();
 		levelScores = new HashMap<String, Integer>();
 		powerUpDefinitions = new HashMap<String, Integer>();
@@ -27,6 +27,14 @@ public class PlayerProgress {
 
 	public void setPredatorSpeedIndex(int predatorSpeedIndex) {
 		this.predatorSpeedIndex = predatorSpeedIndex;
+	}
+	
+	public int getMaxPredatorPowerUps() {
+		return maxPredatorPowerUps;
+	}
+	
+	public void setMaxPredatorPowerUps(int maxPredatorPowerUps) {
+		this.maxPredatorPowerUps = maxPredatorPowerUps;
 	}
 	
 	public boolean isLevelLocked(int levelNumber) {

--- a/Code/data/SandboxConfiguration.java
+++ b/Code/data/SandboxConfiguration.java
@@ -7,7 +7,8 @@ public class SandboxConfiguration {
 	private int mazeWidth;
 	private int mazeHeight;
 	private int numPrey;
-	// maze generation parameters...
+	private int maxPredatorPowerUps;
+	private int powerUpStrengths;
 	
 	public SandboxConfiguration() {
 		predatorSpeedIndex = 4;
@@ -15,15 +16,20 @@ public class SandboxConfiguration {
 		mazeWidth = 8;
 		mazeHeight = 8;
 		numPrey = 2;
+		maxPredatorPowerUps = 5;
+		powerUpStrengths = 2;
 	}
 	
 	public SandboxConfiguration(int predatorSpeedIndex, int preySpeedIndex, 
-			int mazeWidth, int mazeHeight, int numPrey) {
+			int mazeWidth, int mazeHeight, int numPrey, int maxPredatorPowerUps,
+			int powerUpStrengths) {
 		this.predatorSpeedIndex = predatorSpeedIndex;
 		this.preySpeedIndex = preySpeedIndex;
 		this.mazeWidth = mazeWidth;
 		this.mazeHeight = mazeHeight;
 		this.numPrey = numPrey;
+		this.maxPredatorPowerUps = maxPredatorPowerUps;
+		this.powerUpStrengths = powerUpStrengths;
 	}
 
 	public int getPredatorSpeedIndex() {
@@ -46,6 +52,14 @@ public class SandboxConfiguration {
 		return numPrey;
 	}
 
+	public int getMaxPredatorPowerUps() {
+		return maxPredatorPowerUps;
+	}
+	
+	public int getPowerUpStrengths() {
+		return powerUpStrengths;
+	}
+	
 	public void setPredatorSpeedIndex(int predatorSpeedIndex) {
 		this.predatorSpeedIndex = predatorSpeedIndex;
 	}
@@ -64,5 +78,13 @@ public class SandboxConfiguration {
 
 	public void setNumPrey(int numPrey) {
 		this.numPrey = numPrey;
+	}
+	
+	public void setMaxPredatorPowerUps(int maxPredatorPowerUps) {
+		this.maxPredatorPowerUps = maxPredatorPowerUps;
+	}
+	
+	public void setPowerUpStrengths(int powerUpStrengths) {
+		this.powerUpStrengths = powerUpStrengths;
 	}
 }

--- a/Code/ui/GameScreen.java
+++ b/Code/ui/GameScreen.java
@@ -27,6 +27,8 @@ class GameScreen extends MenuScreen {
 	private final UserInputProcessor inputProc;
 	private List<PowerUpButton> powerUpButtons;
 	
+	private final static int NUM_POWER_UP_BUTTONS = 5;
+	
 	public GameScreen(ScreenManager manager) {
 		super(manager);
 		
@@ -60,9 +62,7 @@ class GameScreen extends MenuScreen {
 		
 		// Create the Power Up buttons 
 		powerUpButtons = new ArrayList<PowerUpButton>();
-		Predator predator = getPredator();
-		int numPowerUps = predator.getMaxPowerUp();
-		for (int i = 0; i < numPowerUps; ++i) {
+		for (int i = 0; i < NUM_POWER_UP_BUTTONS; ++i) {
 			final int index = i;
 			PowerUpButton button = new PowerUpButton(getSkin());
 			powerUpButtons.add(button);
@@ -116,6 +116,15 @@ class GameScreen extends MenuScreen {
 	protected void doShow() {
 		// Set up the intial view
 		cameraManager.setInitialViewport();
+		
+		// Make sure the right number of power up buttons are visible
+		Predator predator = getPredator();
+		int numPowerUps = predator.getMaxPowerUp(); 
+		for (int i = 0; i < NUM_POWER_UP_BUTTONS; ++i) {
+			PowerUpButton button = powerUpButtons.get(i);
+			boolean visible = (i < numPowerUps);
+			button.setVisible(visible);
+		}
 	}
 	
 	@Override
@@ -123,9 +132,11 @@ class GameScreen extends MenuScreen {
 		
 		Predator predator = getPredator();
 		int numPowerUps = predator.getMaxPowerUp();
-		for (int i = 0; i < numPowerUps; ++i) {
-			PowerUp powerUp = predator.getStoredPowerUp(i);
-			powerUpButtons.get(i).setPowerUp(powerUp);
+		for (int i = 0; i < NUM_POWER_UP_BUTTONS; ++i) {
+			if (i < numPowerUps) {
+				PowerUp powerUp = predator.getStoredPowerUp(i);
+				powerUpButtons.get(i).setPowerUp(powerUp);
+			}
 		}
 		
 		PredatorPreyGame game = getManager().getGame();


### PR DESCRIPTION
- The number of power ups that can be used in a given level or in
  sandbox mode is now read from the config files.
- Power ups are now included in sandbox mode. The number of power ups is
  just relative to the maze size. All power up types are allowed. The
  strength of all power ups is read from the sandbox config.
- The size of an agent body relative to the square size is read from the
  Physics config.
- The background work for setting the number of power ups and their
  strengths via the GUI for sandbox mode has been added to GameDataManager
  (i.e. these values can be read/written to preferences), but this has not
  yet been added to the GUI.
