### PR TITLE
Fix direction bug

### DIFF
--- a/Code/input/UserInputProcessor.java
+++ b/Code/input/UserInputProcessor.java
@@ -10,12 +10,13 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.input.GestureDetector.GestureListener;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
+//import com.badlogic.gdx.math.Vector3;
 
 public class UserInputProcessor implements InputProcessor, GestureListener {
 
 	private Move mMove;
 	private Direction mPressedMove;
+	@SuppressWarnings("unused")
 	private boolean mPressedEnter;
 	
 	// Camera movement
@@ -26,6 +27,7 @@ public class UserInputProcessor implements InputProcessor, GestureListener {
 	private final float mCamZoomSize = 0.2f;
 	public final LinkedList<Direction> mPressedCamKeys;
 
+	@SuppressWarnings("unused")
 	private CameraAccessor mCameraAccessor;
 	
 	public UserInputProcessor(CameraAccessor ca) {
@@ -214,8 +216,10 @@ public class UserInputProcessor implements InputProcessor, GestureListener {
 	}
 	
 	public void reset() {
+		mMove.clear();
 		mPressedMove = Direction.None;
 		mPressedCamKeys.clear();
+		mPressedEnter = false;
 	}
 
 	@Override

--- a/Code/logic/Move.java
+++ b/Code/logic/Move.java
@@ -31,8 +31,7 @@ public class Move {
 	 * Sets the move direction to None.
 	 */
 	public Move() {
-		this.dir = Direction.None;
-		this.usePowerUpIndex = -1;
+		clear();
 	}
 	
 	/**
@@ -80,5 +79,15 @@ public class Move {
 	 */
 	public void setUsePowerUpIndex(int powerUpIndex) {
 		this.usePowerUpIndex = powerUpIndex;
+	}
+	
+	/**
+	 * Remove any move information. 
+	 * More specifically, this sets the move direction to 'None' and sets the 
+	 * use power up index to -1 to indicate no power up should be used.
+	 */
+	public void clear() {
+		setDirection(Direction.None);
+		setUsePowerUpIndex(-1);
 	}
 }

--- a/Code/ui/GameScreen.java
+++ b/Code/ui/GameScreen.java
@@ -154,6 +154,9 @@ class GameScreen extends MenuScreen {
 	
 	private void gameFinished(GameOver reason) {
 		
+		// Clear any stored user input
+		inputProc.reset();
+		
 		// Grab the game from the screen manager
 		PredatorPreyGame game = getManager().getGame();
 		


### PR DESCRIPTION
The predator would remember the last move direction from the previous
game, so when another game started, the predator would already be
moving. This was inconsistent and looked wrong.
To fix, clear all stored user input when the game ends.
