### PR TITLE
Make appearance of locked buttons clearer

### DIFF
--- a/Code/assets/data/ui/uiskin.json
+++ b/Code/assets/data/ui/uiskin.json
@@ -4,8 +4,8 @@ com.badlogic.gdx.graphics.Color: {
 	light_grey: { r: 0.8, g: 0.8, b: 0.8, a: 1 },
 	white: { r: 1, g: 1, b: 1, a: 1 },
 	red: { r: 1, a: 1 },
-	black: { a: 1 },
-	grey: { r: 0.7, g: 0.7, b: 0.7, a: 1 }
+	grey: { r: 0.7, g: 0.7, b: 0.7, a: 1 },
+	black: { a: 1 }
 },
 com.badlogic.gdx.graphics.g2d.BitmapFont: {
 	default-font: { file: default.fnt }
@@ -23,9 +23,11 @@ com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
 	default: {
 		font: default-font,
 		fontColor: { a: 1, b: 1, g: 1, r: 1 },
-		disabledFontColor: { a: 1, b: 0.8, g: 0.8, r: 0.8 },
+		downFontColor: { a: 1, r: 1 },
+		disabledFontColor: { a: 1, b: 0.7, g: 0.7, r: 0.7 },
 		up: default-round,
-		down: default-round-down
+		down: default-round,
+		disabled: default-round-down
 	},
 	toggle: {
 		font: default-font,

--- a/Code/ui/LevelsScreen.java
+++ b/Code/ui/LevelsScreen.java
@@ -106,6 +106,7 @@ class LevelsScreen extends MenuScreen {
 		for (Integer levelNumber : levelButtons.keySet()) {
 			Button button = levelButtons.get(levelNumber);
 			boolean locked = progress.isLevelLocked(levelNumber);
+			button.setDisabled(locked);
 			if (locked) {
 				button.setTouchable(Touchable.disabled);
 			} else {


### PR DESCRIPTION
Need to make it clearer when a button is not available (i.e. locked). Do
this by changing the default text button style attributes so that
enabled/disabled buttons are easily differentiated.
