### PR TITLE
Fix maze background size

### DIFF
--- a/Code/assets/data/config/renderer_config.json
+++ b/Code/assets/data/config/renderer_config.json
@@ -2,13 +2,9 @@
 	allowRotations: true
 	wallTextureFilename: wall_2.png
 	wallTextureScale: 1
-	backgroundBottomLeft: {
-		x: 0
-		y: 0
-	}
-	backgroundTopRight: {
-		x: 80
-		y: 80
+	backgroundSize: {
+		x: 100
+		y: 100
 	}
 	backroundFilename: background_2.png
 	animationGroupDefinitions: [

--- a/Code/game/PredatorPreyGame.java
+++ b/Code/game/PredatorPreyGame.java
@@ -124,6 +124,17 @@ public class PredatorPreyGame extends Game implements GameStatus {
 	}
 	
 	public void resetGame() {
+		
+		// Calculate the size of the maze in world coordinates. Use this for
+		// the background image size.
+		float squareSize = physicsConfig.getSquareSize();
+		PolygonShape shape = gameConfig.getDimensions();
+		float width = (shape.getMaxX() - shape.getMinX() + 1) * squareSize;
+		float height = (shape.getMaxY() - shape.getMinY() + 1) * squareSize;
+		renderer.setBackgroundSize(new Vector2(width, height));
+		
+		// Rebuild the back end game logic and physics processor from the 
+		// configurations.
 		gameLogic = new GameLogic(gameConfig);
 		physProc = new PhysicsProcessorBox2D(gameLogic.getGameState(), 
 				physicsConfig);

--- a/Code/render/Renderer.java
+++ b/Code/render/Renderer.java
@@ -7,6 +7,7 @@ import physics.PhysicsBodyAgent;
 import physics.PhysicsGameWorld;
 
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.physics.box2d.Box2DDebugRenderer;
 
@@ -77,6 +78,10 @@ public class Renderer {
 	public void loadTextures(RendererConfiguration config) {
 		textureDrawer = new TextureDrawer(config);
 		texturesLoaded = true;
+	}
+	
+	public void setBackgroundSize(Vector2 size) {
+		textureDrawer.setBackgroundSize(size);
 	}
 	
 	private void drawBodies(List<? extends PhysicsBody> bodies, 

--- a/Code/render/RendererConfiguration.java
+++ b/Code/render/RendererConfiguration.java
@@ -3,9 +3,6 @@ package render;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import com.badlogic.gdx.math.Vector2;
 
 /**
@@ -16,7 +13,6 @@ import com.badlogic.gdx.math.Vector2;
  * 
  * @version 2016-03-25
  */
-@XmlRootElement(name = "RendererConfiguration")
 public class RendererConfiguration {
 	
 	public static final String ANIMATION_DOWN_STOP = "DOWN-STOP";
@@ -33,9 +29,7 @@ public class RendererConfiguration {
 	private String wallTextureFilename;
 	private float wallTextureScale;
 	
-	private Vector2 backgroundBottomLeft;
-	private Vector2 backgroundTopRight;
-	
+	private Vector2 backgroundSize;
 	private String backroundFilename;
 	
 	private List<AnimationGroupDefinition> animationGroupDefinitions =
@@ -51,8 +45,7 @@ public class RendererConfiguration {
 		this.allowRotations = true;
 		this.wallTextureFilename = "wall.png";
 		this.wallTextureScale = 1.0f;
-		this.backgroundBottomLeft = new Vector2(0f, 0f);
-		this.backgroundTopRight = new Vector2(100f, 100f);
+		this.backgroundSize = new Vector2(100f, 100f);
 		this.backroundFilename = "background_1.png";
 		
 		setupDefaultAnimationDefinitions();
@@ -68,7 +61,6 @@ public class RendererConfiguration {
 		return animationGroupDefinitions;
 	}
 	
-	@XmlElement (name = "AnimationGroupDefinition")
 	public void setAnimationGroupDefinitions(
 			List<AnimationGroupDefinition> animationGroupDefinitions) {
 		this.animationGroupDefinitions = animationGroupDefinitions;
@@ -78,35 +70,31 @@ public class RendererConfiguration {
 		return this.backroundFilename;
 	}
 	
-	@XmlElement (name = "BackgroundFilename")
 	public void setBackgroundFilename(String filename) {
 		this.backroundFilename = filename;
 	}
 	
 	/**
-	 * The background dimensions should be given in world measurements and not
-	 * pixels
-	 * @param bottomLeft - the bottom left coordinate of the background image
-	 * @param topRight - the top right coordinate of the background image
+	 * Set the background size. The dimensions should be given in world 
+	 * measurements and not pixels.
+	 * The x value of the provided vector is the width and the y value the 
+	 * height. 
+	 * 
+	 * @param size - the width and height of the background in world 
+	 * coordinates.
 	 */
-	public void setBackgroundDimensions(Vector2 bottomLeft, Vector2 topRight) {
-		this.backgroundBottomLeft = bottomLeft;
-		this.backgroundTopRight = topRight;
+	public void setBackgroundSize(Vector2 size) {
+		this.backgroundSize = size;
 	}
 	
-	public Vector2 getBackgroundBottomLeft() {
-		return this.backgroundBottomLeft;
-	}
-	
-	public Vector2 getBackgroundTopRight() {
-		return this.backgroundTopRight;
+	public Vector2 getBackgroundSize() {
+		return this.backgroundSize;
 	}
 	
 	public float getWallTextureScale() {
 		return this.wallTextureScale;
 	}
 	
-	@XmlElement (name = "WallTextureScale")
 	public void setWallTextureScale(float scale) {
 		if (scale < 0 || scale > 1) {
 			throw new IllegalArgumentException("Scale must be between 0 and 1");
@@ -118,7 +106,6 @@ public class RendererConfiguration {
 		return this.wallTextureFilename;
 	}
 	
-	@XmlElement (name = "WallTextureFilename")
 	public void setWallTextureFilename(String filename) {
 		this.wallTextureFilename = filename;
 	}
@@ -127,7 +114,6 @@ public class RendererConfiguration {
 		return allowRotations;
 	}
 
-	@XmlElement (name = "AllowRotations")
 	public void setAllowRotations(boolean allowRotations) {
 		this.allowRotations = allowRotations;
 	}

--- a/Code/render/TextureDrawer.java
+++ b/Code/render/TextureDrawer.java
@@ -51,6 +51,10 @@ public class TextureDrawer {
 		shapeDrawer = new ShapeDrawer();
 	}
 	
+	public void setBackgroundSize(Vector2 size) {
+		rendererConfig.setBackgroundSize(size);
+	}
+	
 	/**
 	 * Draws the background image at the specified world coordinates. Assumes
 	 * the image has already been loaded into memory.
@@ -60,16 +64,11 @@ public class TextureDrawer {
 	 * @param projMatrix - the projection matrix
 	 */
 	public void drawBackground(float x, float y, Matrix4 projMatrix) {
-		Vector2 bottomLeft = rendererConfig.getBackgroundBottomLeft();
-		Vector2 topRight = rendererConfig.getBackgroundTopRight();
+		Vector2 backgroundSize = rendererConfig.getBackgroundSize();
 		
 		spriteBatch.begin();
 		spriteBatch.setProjectionMatrix(projMatrix);
-		spriteBatch.draw(background, 
-				         bottomLeft.x,
-				         bottomLeft.y,
-				         topRight.x - bottomLeft.x, 
-				         topRight.y - bottomLeft.y);
+		spriteBatch.draw(background, x, y, backgroundSize.x, backgroundSize.y);
 		spriteBatch.end();
 	}
 	


### PR DESCRIPTION
The size of the maze background image is now adjusted to fit the size of the maze.
When the game is reset, the Renderer is informed of the new background size. It passes this onto the TextureDrawer which actually does the drawing.
