### PR TITLE
Fix settings screen back button

### DIFF
--- a/Code/ui/MainMenuScreen.java
+++ b/Code/ui/MainMenuScreen.java
@@ -5,10 +5,13 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.Cell;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 
@@ -43,8 +46,20 @@ class MainMenuScreen extends MenuScreen {
 				"Levels", ScreenName.Levels);
 		Button sandboxButton = createScreenChangeButton(
 				"Sandbox", ScreenName.Sandbox);
-		Button settingsButton = createScreenChangeButton(
-				"Settings", ScreenName.Settings);
+		
+		// Create the Settings button. It needs to tell the Settings screen 
+		// that this is the screen to return to afterwards, as well as changing
+		// the screen
+		Button settingsButton = new TextButton("Settings", getSkin());
+		settingsButton.addListener(new ClickListener() {
+			@Override
+			public void clicked(InputEvent event, float x, float y) {
+		    	SettingsScreen settingsScreen = 
+		    			(SettingsScreen) getManager().getScreen(ScreenName.Settings);
+		    	settingsScreen.setPreviousScreen(ScreenName.MainMenu);
+				getManager().changeScreen(ScreenName.Settings);
+			}
+		});
 		
 		// Create a table and layout the buttons
 		Table table = new Table();

--- a/Code/ui/PauseScreen.java
+++ b/Code/ui/PauseScreen.java
@@ -42,6 +42,9 @@ class PauseScreen extends MenuScreen {
                     screenName = ScreenName.Game;
                 }
                 else if (SETTINGS_BUTTON.equals(buttonId)) {
+                	SettingsScreen settingsScreen = 
+                			(SettingsScreen) getManager().getScreen(ScreenName.Settings);
+                	settingsScreen.setPreviousScreen(ScreenName.Pause);
                     screenName = ScreenName.Settings;
                 }
                 else if (HOME_BUTTON.equals(buttonId)) {

--- a/Code/ui/SettingsScreen.java
+++ b/Code/ui/SettingsScreen.java
@@ -5,12 +5,15 @@ import sound.SoundConfiguration;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.Cell;
 import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Slider;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 
 import data.DataManager;
 import functional.Consumer;
@@ -21,11 +24,19 @@ class SettingsScreen extends MenuScreen {
 	
 	private SoundConfiguration soundConfig;
 	
+	private ScreenName previousScreen;
+	
 	private final float SLIDER_PADDING = 5f;
 	private final float TABLE_PADDING = 20f;
 	
 	public SettingsScreen(ScreenManager manager) {
 		super(manager);
+		
+		previousScreen = ScreenName.MainMenu;
+	}
+	
+	public void setPreviousScreen(ScreenName previousScreen) {
+		this.previousScreen = previousScreen;
 	}
 
 	@Override
@@ -96,10 +107,14 @@ class SettingsScreen extends MenuScreen {
         													"Music",
         													SLIDER_PADDING);
 
-        // Add the main menu button
-		Button menuButton = createScreenChangeButton(
-				"Main menu", ScreenName.MainMenu);
-		
+        // Add the back button
+		Button backButton = new TextButton("Back", getSkin());
+		backButton.addListener(new ClickListener() {
+			@Override
+			public void clicked(InputEvent event, float x, float y) {
+				getManager().changeScreen(previousScreen);
+			}
+		});
 		
 		// Layout the widgets in a table
 		Table table = new Table();
@@ -116,7 +131,7 @@ class SettingsScreen extends MenuScreen {
 		musicSliderCell.pad(TABLE_PADDING);
 		table.row();
 
-		Cell<Button> menuCell = table.add(menuButton);
+		Cell<Button> menuCell = table.add(backButton);
 		menuCell.pad(TABLE_PADDING);
 		menuCell.colspan(2);
 		


### PR DESCRIPTION
The settings screen can be accessed from the main menu and the pause
screen. It needs to return to whichever screen it was accessed from.
Store the previous screen name in the settings screen. This is set when
the settings button is pressed on the main menu or pause screen.